### PR TITLE
Feature/inline type support

### DIFF
--- a/.buildcomrc
+++ b/.buildcomrc
@@ -18,7 +18,7 @@ css_preprocessor: 'sass'
 css_modules: false
 # Generate a README.md file for each component.
 generate_readme: true
-# [COMING SOON] Output component types in their own subfolder (will output in the components index file if false).
+# Output component types in their own subfolder (will output in the components index file if false).
 create_types_subfolder: false
 # If true, example code will be added to the component files. If false, the files will be bare-bones.
 output_example_code: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buildcom",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "bin": {
     "buildcom": "index.js",
     "bcreg": "scripts/generate-register.js"

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,8 @@ You can specify some defaults by creating a `.buildcomrc` file in your home dire
     css_preprocessor: 'sass'
     # use the CSS module format?
     css_modules: false
+    # Output component types in their own subfolder (will output in the components index file if false).
+    create_types_subfolder: false
     # Generate a README.md file for each component.
     generate_readme: true
     # If true, example code will be added to the component files. If false, the files will be bare-bones.
@@ -147,7 +149,6 @@ buildcom --name "example component" -sjr -d 'images' --css "scss"
 ## Possible future developments
 - Add the ability to generate for frameworks other than React.
 - Renames files instead of needed an exact copy to exist in the scaffold folder, will allow for more flexibility of naming choices.
-- Add the ability to use inline Typescript types instead of requiring them to be in a subdirectory.
 - Will bring argument mode into parity with the config file mode and the questionaire mode.
 ## Known issues
 - Currently buildcom does not check if the component name already exists in the current directory, if you try to generate a component with the same name as an existing component, it will overwrite the existing components files.

--- a/scaffold/index.tsx
+++ b/scaffold/index.tsx
@@ -1,11 +1,8 @@
 import React from 'react'
 
-/* Import Types */
-import Props from './types/props'
-
 /* Import Stylesheet */
 %styleimport%
-
+%TsString%
 /* Render component */
 export const %ComponentExample%: React.FC<Props> = ({ name, colour }: Props) =>
   <div className={%classes%}>

--- a/scripts/component-generator.js
+++ b/scripts/component-generator.js
@@ -59,7 +59,7 @@ module.exports = comGen = answers => {
     generateDirectory(componentDir)
   
     // Generate the index file
-    generateFile(`index.${jsext('x')}`, props)
+    generateFile(`index.${jsext('x')}`, props, createTypesFolder)
   
     // Generate the stories file
     createStories ? generateFile(`index.stories.${storyExt(chooseStorybook)}`, props) : skip('story files')
@@ -70,20 +70,21 @@ module.exports = comGen = answers => {
     // Generate the spec file
     createSpec ? generateFile(`index.${test_file_name}.${jsext('x')}`, props) : skip('test files')
     
-    // Extra things are needed if TypeScript is enabled
+    // Extra things are needed if TypeScript is enabled and it is not inlined
     if (useTS)  {     
-      // Create the types folder
-      generateDirectory(path.join(componentDir, 'types'))
-
-      const extraProps = {
-        ...props,
-        customDir: 'types'
+      if (createTypesFolder) {
+        // Create the types folder
+        generateDirectory(path.join(componentDir, 'types'))
+  
+        const extraProps = {
+          ...props,
+          customDir: 'types'
+        }
+        
+        // Create the props interface
+        generateFile('props.d.ts', extraProps)
       }
-      
-      // Create the props interface
-      generateFile('props.d.ts', extraProps)
-    }
-
+    } 
     
     // Generate the readme file
     createReadme && generateFile('README.md', props)


### PR DESCRIPTION
## 🚀 Overview: 
Allows for type definitions to be added inline in the index file instead of being placed in a `types` subfolder

## 🤔 Reason: 

Not everybody wants subfolders and separate files for types.

## 🔨Work carried out:

- [x] Adds new placeholder to scaffold
- [x] Updates scripts
- [x] Updates readme